### PR TITLE
Add rawVforkSyscall to list of syscall package calls to squash superfluous errors

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -4,11 +4,12 @@ import (
 	"debug/elf"
 	"encoding/json"
 	"fmt"
-	"github.com/opencontainers/runtime-spec/specs-go"
 	"log"
 	"os"
 	"os/exec"
 	"strings"
+
+	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
 func openElf(filename string) *elf.File {
@@ -132,7 +133,8 @@ func parseFunctionName(instruction string) string {
 func isSyscallPkgCall(arch specs.Arch, instruction string) bool {
 	j := getCallOpByArch(arch)
 	return strings.Contains(instruction, j+"syscall.Syscall(SB)") || strings.Contains(instruction, j+"syscall.Syscall6(SB)") ||
-		strings.Contains(instruction, j+"syscall.RawSyscall(SB)") || strings.Contains(instruction, j+"syscall.RawSyscall6(SB)")
+		strings.Contains(instruction, j+"syscall.RawSyscall(SB)") || strings.Contains(instruction, j+"syscall.RawSyscall6(SB)") ||
+		strings.Contains(instruction, j+"syscall.rawVforkSyscall(SB)")
 }
 
 func isRuntimeSyscall(arch specs.Arch, instruction, currentFunction string) bool {
@@ -142,10 +144,11 @@ func isRuntimeSyscall(arch specs.Arch, instruction, currentFunction string) bool
 	case specs.ArchX86:
 		isRuntimeSC = (strings.Contains(instruction, "INT $0x80") || strings.Contains(instruction, "SYSENTER"))
 	case specs.ArchX86_64:
-		// there are SYSCALL instructions in each of the 4 functions on the syscall package, so we ignore those
+		// there are SYSCALL instructions in each of the 5 functions on the syscall package, so we ignore those
 		isRuntimeSC = strings.Contains(instruction, "SYSCALL") &&
 			!strings.Contains(currentFunction, "syscall.Syscall") &&
-			!strings.Contains(currentFunction, "syscall.RawSyscall")
+			!strings.Contains(currentFunction, "syscall.RawSyscall") &&
+			!strings.Contains(currentFunction, "syscall.rawVforkSyscall")
 	case specs.ArchARM:
 		isRuntimeSC = strings.Contains(instruction, "SVC $0") || strings.Contains(instruction, "SWI $0")
 	}

--- a/main.go
+++ b/main.go
@@ -4,12 +4,13 @@ import (
 	"bufio"
 	"flag"
 	"fmt"
-	"github.com/opencontainers/runtime-spec/specs-go"
 	"log"
 	"os"
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
 // TODO add a verbose flag and do a proper verbose mode
@@ -237,7 +238,7 @@ func getSyscallList(disassambled *os.File, arch specs.Arch) []string {
 			currentFunction = parseFunctionName(instruction)
 		}
 
-		// function call to one of the 4 functions from the syscall package
+		// function call to one of the 5 functions from the syscall package
 		if isSyscallPkgCall(arch, instruction) {
 			id, err := findSyscallID(arch, previousInstructions, lineCount)
 			if err != nil {


### PR DESCRIPTION
I'm a little unsure about whether this PR is quite right.  I tried running your tool against some binaries, but encountered an error of the following form for each of them:

```
Arch :  SCMP_ARCH_X86_64
Using go tool objdump to disassemble allocate-ipip-addr
Scanning disassembled binary for syscall IDs
2018/05/08 15:49:31 Failed to find syscall ID for line 108802:
	  asm_linux_amd64.s:124	0x47d5d9		0f05			SYSCALL
	reason: Failed to find syscall ID on line:   asm_linux_amd64.s:122	0x47d5d2		488b442408		MOVQ 0x8(SP), AX
Syscalls detected (total: 90): [accept <SNIP /> writev]
Saved seccomp profile at alloc.seccomp
```

Looking at https://golang.org/src/syscall/asm_linux_amd64.s suggested that there was another direct SYSCALL instruction in rawVforkSyscall, so I've added it to the appropriate places.  Having said this, I'm not totally confident it belongs in both places (mostly because this method is supposedly unexported, but also because I haven't took the time to fully figure out what's going on).

The change here suppresses the above error message.  In this example it didn't find any more syscalls.

Hopefully this PR is useful nonetheless.